### PR TITLE
Added LV2 plugin, added Standalone, removed legacy VST2 plugin

### DIFF
--- a/src/tunefish4/Tunefish4.jucer
+++ b/src/tunefish4/Tunefish4.jucer
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <JUCERPROJECT id="hMeUe0" name="Tunefish4" projectType="audioplug" version="4.3.0"
+              defines="JUCE_MODAL_LOOPS_PERMITTED=1"
               bundleIdentifier="org.braincontrol.Tunefish4" includeBinaryInAppConfig="1"
-              buildVST="1" buildVST3="1" buildAU="1" buildRTAS="0" buildAAX="0"
-              pluginName="Tunefish4" pluginDesc="Tunefish4" pluginManufacturer="Brain Control"
+              buildLV2="1" buildVST="0" buildVST3="1" buildAU="1" buildRTAS="0"
+              buildAAX="0" pluginName="Tunefish4" pluginDesc="Tunefish4" pluginManufacturer="Brain Control"
               pluginManufacturerCode="Bctr" pluginCode="Tfs4" pluginChannelConfigs="{2, 2}"
               pluginIsSynth="1" pluginWantsMidiIn="1" pluginProducesMidiOut="0"
               pluginSilenceInIsSilenceOut="0" pluginEditorRequiresKeys="0"
@@ -11,8 +12,8 @@
               pluginAAXCategory="2" companyName="Brain Control" companyWebsite="http://www.tunefish-synth.com"
               companyEmail="payne@braincontrol.org" pluginIsMidiEffectPlugin="0"
               displaySplashScreen="0" reportAppUsage="0" splashScreenColour="Dark"
-              buildAUv3="1" buildStandalone="0" enableIAA="0" cppLanguageStandard="11"
-              companyCopyright="Brain Control" pluginFormats="buildAU,buildAUv3,buildVST,buildVST3"
+              buildAUv3="1" buildStandalone="1" enableIAA="0" companyCopyright="Brain Control"
+              pluginFormats="buildAU,buildLV2,buildStandalone,buildAUv3,buildVST3"
               pluginCharacteristicsValue="pluginIsSynth,pluginWantsMidiIn"
               jucerFormatVersion="1">
   <MAINGROUP id="pOTaV2" name="Tunefish4">
@@ -150,12 +151,12 @@
       </MODULEPATHS>
     </VS2017>
     <LINUX_MAKE targetFolder="Builds/LinuxMakefile" vstFolder="~/src/3rdparty/vst"
-                extraCompilerFlags="-fpermissive" vstLegacyFolder="~/SDKs/VST_SDK/VST2_SDK">
+                extraCompilerFlags="-fpermissive">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" libraryPath="/usr/X11R6/lib/" isDebug="1" optimisation="1"
-                       targetName="Tunefish4"/>
+                       targetName="Tunefish4" enablePluginBinaryCopyStep="0"/>
         <CONFIGURATION name="Release" libraryPath="/usr/X11R6/lib/" isDebug="0" optimisation="3"
-                       targetName="Tunefish4"/>
+                       targetName="Tunefish4" enablePluginBinaryCopyStep="0"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_core" path="..\..\..\..\3rdparty\JUCE\modules"/>
@@ -176,9 +177,9 @@
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="1"/>
     <MODULE id="juce_audio_devices" showAllCode="1" useLocalCopy="1"/>
-    <MODULE id="juce_audio_formats" showAllCode="1" useLocalCopy="1" useGlobalPath="0"/>
+    <MODULE id="juce_audio_formats" showAllCode="1" useLocalCopy="1" useGlobalPath="1"/>
     <MODULE id="juce_audio_plugin_client" showAllCode="1" useLocalCopy="1"/>
-    <MODULE id="juce_audio_processors" showAllCode="1" useLocalCopy="1" useGlobalPath="0"/>
+    <MODULE id="juce_audio_processors" showAllCode="1" useLocalCopy="1" useGlobalPath="1"/>
     <MODULE id="juce_audio_utils" showAllCode="1" useLocalCopy="1"/>
     <MODULE id="juce_core" showAllCode="1" useLocalCopy="1"/>
     <MODULE id="juce_data_structures" showAllCode="1" useLocalCopy="1"/>
@@ -190,5 +191,5 @@
   <LIVE_SETTINGS>
     <OSX enableCxx11="1"/>
   </LIVE_SETTINGS>
-  <JUCEOPTIONS JUCE_QUICKTIME="disabled" JUCE_WEB_BROWSER="0" JUCE_USE_WIN_WEBVIEW2="0"/>
+  <JUCEOPTIONS JUCE_QUICKTIME="disabled" JUCE_WEB_BROWSER="0" JUCE_USE_WIN_WEBVIEW2="0" JUCE_VST3_CAN_REPLACE_VST2="0" />
 </JUCERPROJECT>


### PR DESCRIPTION
Update Tunefish4.jucer to make it compile in modern Linux systems with modern JUCER version.

VST2 is legacy, and required manually downloading some SDK files from a web archive. It's easier to just disable it and focus only on VST3. https://forum.juce.com/t/vst-sdk-3-6-12/30703

If needed, VST2 can be easily added back by setting `buildVST="1"` and by adding `buildVST` to `pluginFormats`.

LV2 plugin can also easily be built, thanks to JUCE. I've quickly tested it using Jalv and it works fine: https://drobilla.net/software/jalv.html

The Standalone version also works fine.

Disabling the automatic copy/install of the plugins to the home directory is helpful when packaging this software. OB-Xd on Arch linux also does it: https://gitlab.archlinux.org/archlinux/packaging/packages/ob-xd/-/blob/main/skip-plugin-copy.patch

---

How to build:

    cd src/tunefish4
    Projucer --resave Tunefish4.jucer
    Builds/LinuxMakefile
    make CONFIG=Release

Although it works fine, it complains with message:

    JUCE Assertion failure in juce_audio_plugin_client_LV2.cpp:133

I don't know how to fix it, and it doesn't affect the main usage.